### PR TITLE
feat: add replay_file_name as column in matches mart

### DIFF
--- a/models/intermediate/replay_matches.sql
+++ b/models/intermediate/replay_matches.sql
@@ -1,5 +1,6 @@
 SELECT
   d.id AS replay_id,
+  d.fileName AS replay_file_name,
   m.scriptName AS replay_map,
   d.engineVersion AS engine,
   d.gameVersion AS game_version,

--- a/models/intermediate/schema.yml
+++ b/models/intermediate/schema.yml
@@ -56,6 +56,9 @@ models:
       - name: replay_id
         data_tests:
           - unique
+      - name: replay_file_name
+        data_tests:
+          - not_null
       - name: replay_start_time
         data_tests:
           - not_null

--- a/models/marts/matches.sql
+++ b/models/marts/matches.sql
@@ -15,6 +15,7 @@ SELECT
   game_duration,
   is_ranked,
   replay_id,
+  replay_file_name,
   engine,
   game_version,
   is_public

--- a/models/marts/schema.yml
+++ b/models/marts/schema.yml
@@ -20,6 +20,10 @@ models:
           https://www.beyondallreason.info/replays?gameId={replay_id}
         data_tests:
           - unique
+      - name: replay_file_name
+        data_type: string
+        description: |
+          Object name of the replay demo on BAR's public storage.
       - name: start_time
         data_type: timestamp
         description: UTC time of when the match started


### PR DESCRIPTION
Right now to go from a match in the dataset to a replay file you have to query the bar-db api with a replay id, get the filename, then download from ovh storage using that filename. This will allow users to skip the api call and go right to storage.

Sequelize definition showing existence of this column (and that it's non-null): https://github.com/beyond-all-reason/bar-db/blob/67ee6ba47354542b23edac64dc262e85521adefd/src/model/db/demo.ts#L76